### PR TITLE
Updated to 1.16 + using NBT in item data now.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.15</version>
+            <version>1.16.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/songoda/epicanchors/EpicAnchors.java
+++ b/src/main/java/com/songoda/epicanchors/EpicAnchors.java
@@ -9,6 +9,8 @@ import com.songoda.core.configuration.Config;
 import com.songoda.core.gui.GuiManager;
 import com.songoda.core.hooks.EconomyManager;
 import com.songoda.core.hooks.HologramManager;
+import com.songoda.core.nms.NmsManager;
+import com.songoda.core.nms.nbt.NBTItem;
 import com.songoda.core.utils.TextUtils;
 import com.songoda.epicanchors.anchor.Anchor;
 import com.songoda.epicanchors.anchor.AnchorManager;
@@ -55,6 +57,9 @@ public class EpicAnchors extends SongodaPlugin {
         saveToFile();
         HologramManager.removeAllHolograms();
     }
+
+    @Override
+    public void onDataLoad() {}
 
     @Override
     public void onPluginEnable() {
@@ -136,7 +141,7 @@ public class EpicAnchors extends SongodaPlugin {
         // verify that this is a anchor
         if (anchor.getLocation().getBlock().getType() != Settings.MATERIAL.getMaterial().getMaterial()) return;
         // grab the name
-        String name = Methods.formatName(anchor.getTicksLeft(), false).trim();
+        String name = Methods.formatName(anchor.getTicksLeft()).trim();
         Location location = correctHeight(anchor.getLocation());
         // create the hologram
         HologramManager.updateHologram(location, name);
@@ -168,9 +173,15 @@ public class EpicAnchors extends SongodaPlugin {
     }
 
     public int getTicksFromItem(ItemStack item) {
+        NBTItem nbtItem = NmsManager.getNbt().of(item);
+        if (nbtItem.has("ticks")) {
+            return nbtItem.getNBTObject("ticks").asInt();
+        }
+
+        // Legacy code. Tries to get the ticks remaining from hidden text.
         if (!item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) return 0;
         if (item.getItemMeta().getDisplayName().contains(":")) {
-            return NumberUtils.toInt(item.getItemMeta().getDisplayName().replace("\u00A7", "").split(":")[0], 0);
+            return Integer.parseInt(item.getItemMeta().getDisplayName().replace("\u00A7", "").split(":")[0], 0);
         }
         return 0;
     }
@@ -178,7 +189,7 @@ public class EpicAnchors extends SongodaPlugin {
     public ItemStack makeAnchorItem(int ticks) {
         ItemStack item = Settings.MATERIAL.getMaterial().getItem();
         ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(Methods.formatName(ticks, true));
+        meta.setDisplayName(Methods.formatName(ticks));
         ArrayList<String> lore = new ArrayList<>();
         String[] parts = Settings.LORE.getString().split("\\|");
         for (String line : parts) {
@@ -186,7 +197,10 @@ public class EpicAnchors extends SongodaPlugin {
         }
         meta.setLore(lore);
         item.setItemMeta(meta);
-        return item;
+
+        NBTItem nbtItem = NmsManager.getNbt().of(item);
+        nbtItem.set("ticks", ticks);
+        return nbtItem.finish();
     }
 
     public CommandManager getCommandManager() {

--- a/src/main/java/com/songoda/epicanchors/EpicAnchors.java
+++ b/src/main/java/com/songoda/epicanchors/EpicAnchors.java
@@ -181,7 +181,7 @@ public class EpicAnchors extends SongodaPlugin {
         // Legacy code. Tries to get the ticks remaining from hidden text.
         if (!item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) return 0;
         if (item.getItemMeta().getDisplayName().contains(":")) {
-            return Integer.parseInt(item.getItemMeta().getDisplayName().replace("\u00A7", "").split(":")[0], 0);
+            return Integer.parseInt(item.getItemMeta().getDisplayName().replace("\u00A7", "").split(":")[0]);
         }
         return 0;
     }

--- a/src/main/java/com/songoda/epicanchors/utils/Methods.java
+++ b/src/main/java/com/songoda/epicanchors/utils/Methods.java
@@ -18,19 +18,15 @@ public class Methods {
 
     private static Map<String, Location> serializeCache = new HashMap<>();
 
-    public static String formatName(int ticks2, boolean full) {
+    public static String formatName(int ticks) {
 
-        String remaining = TimeUtils.makeReadable((ticks2 / 20L) * 1000L);
+        String remaining = TimeUtils.makeReadable((ticks / 20L) * 1000L);
 
-        String name = Settings.NAMETAG.getString().replace("{REMAINING}", (ticks2 <= 0)
+        String name = Settings.NAMETAG.getString().replace("{REMAINING}", (ticks <= 0)
                 ? EpicAnchors.getInstance().getLocale().getMessage("infinite").getMessage() : remaining);
 
-        String info = "";
-        if (full) {
-            info += TextUtils.convertToInvisibleString(ticks2 + ":");
-        }
 
-        return info + TextUtils.formatText(name);
+        return TextUtils.formatText(name);
     }
 
     /**


### PR DESCRIPTION
Compiles successfully on 1.16.1 and seems to work fine without any issues.

During testing, I added debug to help, such as Chunk#isLoaded calls to check if it was indeed loaded, and it was.
I also took the chance to change the legacy hidden text method to a NBT-based approach. Old items are still compatible.

Holograms, economy/XP costs and menus work perfectly. "Allow Anchor Breaking" also works perfectly.
Needs testing with EpicSpawners, but it should be fine as well.

Also added the new SongodaCore onDataLoad call but didn't move anything to it yet.